### PR TITLE
feat: support query

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -99,24 +99,24 @@ class AppleStrategy extends passport.Strategy {
      * @param {string} [options.state]
      */
     authenticate(req, options = {}) {
-        if (req.body && req.body.error) {
-            if (req.body.error === 'user_cancelled_authorize') {
+        if (req.query && req.query.error) {
+            if (req.query.error === 'user_cancelled_authorize') {
                 return this.fail({ message: 'User cancelled authorize' });
             } else {
-                return this.error(new AuthorizationError(req.body.error, req.body.error));
+                return this.error(new AuthorizationError(req.query.error, req.query.error));
             }
         }
 
         let callbackURL = options.callbackURL || this._callbackURL;
 
-        if (req.body && req.body.code) {
-            const state = req.body.state;
+        if (req.query && req.query.code) {
+            const state = req.query.state;
             try {
                 this._stateStore.verify(req, state, (err, ok, state) => {
                     if (err) return this.error(err);
                     if (!ok) return this.fail(state, 403);
 
-                    const code = req.body.code;
+                    const code = req.query.code;
 
                     const params = { grant_type: 'authorization_code' };
                     if (callbackURL) params.redirect_uri = callbackURL;


### PR DESCRIPTION
passport-oauth2와 같은 인터페이스를 위함.
